### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install cuckoo-filter
 ## Usage
 ```javascript
 const CuckooFilter = require('cuckoo-filter').CuckooFilter
-const ScalableFilter = require('cuckoo-filter').ScalableCuckooFilter
+const ScalableCuckooFilter = require('cuckoo-filter').ScalableCuckooFilter
 
 let cuckoo= new CuckooFilter(200, 4, 2) // (Size, Bucket Size, Finger Print Size)
 


### PR DESCRIPTION
To fix this
```
 test node index.js 
/Users/andrew/test/index.js:6
let cuckoo2 = new ScalableCuckooFilter(2000, 4, 2, 2) // (Size, Bucket Size, Finger Print Size, Exponential Scale)
                  ^

ReferenceError: ScalableCuckooFilter is not defined
    at Object.<anonymous> (/Users/andrew/test/index.js:6:19)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:605:10)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:575:3

```